### PR TITLE
configure `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-docstring-first
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.7.4
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -23,7 +23,7 @@ repos:
       - id: taplo-lint
         args: ["--no-schema"]
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.22
+    rev: v0.23
     hooks:
       - id: validate-pyproject
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-docstring-first
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.3
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
+    hooks:
+      - id: prettier
+        args: ["--cache-location=.prettier_cache"]
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+        args: ["--option", "array_auto_collapse=false"]
+      - id: taplo-lint
+        args: ["--no-schema"]
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.22
+    hooks:
+      - id: validate-pyproject
+
+ci:
+  autofix_prs: true
+  autoupdate_schedule: monthly

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # marray
+
 Masked versions of array API compatible arrays

--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -6,6 +6,7 @@ __version__ = "0.0.4"
 
 import numpy as np  # temporarily used in __repr__ and __str__
 
+
 def masked_array(xp):
     """Returns a masked array namespace for an array API backend
 
@@ -23,7 +24,7 @@ def masked_array(xp):
            fill_value=1e+20)
 
     """
-    class MaskedArray():
+    class MaskedArray:
 
         def __init__(self, data, mask=None):
             data = getattr(data, '_data', data)

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -3,8 +3,9 @@
 # - debug reciprocal operator failures
 # - debug statistical function failures
 
-import pytest
 import numpy as np
+import pytest
+
 import marray
 
 dtypes_boolean = ['bool']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,36 @@ test = ["pytest"]
 
 [project.urls]
 Home = "https://github.com/mdhaber/marray"
+
+[tool.ruff]
+target-version = "py310"
+builtins = ["ellipsis"]
+exclude = [".git", ".eggs", "build", "dist", "__pycache__"]
+line-length = 100
+
+[tool.ruff.lint]
+ignore = [
+  "E402", # module level import not at top of file
+  # "E501",  # line too long - let black worry about that
+  "E731",  # do not assign a lambda expression, use a def
+  "UP038", # type union instead of tuple for isinstance etc
+]
+select = [
+  "F",   # Pyflakes
+  "E",   # Pycodestyle
+  "I",   # isort
+  "UP",  # Pyupgrade
+  "TID", # flake8-tidy-imports
+  "W",
+]
+extend-safe-fixes = [
+  "TID252", # absolute imports
+]
+fixable = ["I", "TID252", "UP"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["marray"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+# Disallow all relative imports.
+ban-relative-imports = "all"


### PR DESCRIPTION
This adds a couple of `pre-commit` hooks:
- `trailing-whitespace`, `end-of-file-fixer`, `check-docstring-first`: basic hooks
- `ruff`: linting
- `prettier`: format config files (mostly yaml)
- `taplo`: format toml
- `validate-pyproject`: validate `pyproject.toml`'s project table