### PR TITLE
set up CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates once a week
+      interval: "weekly"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Fetch all history for all branches and tags
 
       - name: Setup environment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  detect-ci-trigger:
+    name: detect ci trigger
+    runs-on: ubuntu-latest
+    if: |
+      github.repository_owner == 'mdhaber'
+      && (github.event_name == 'pull_request' || github.event_name == 'push')
+    outputs:
+      triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: xarray-contrib/ci-trigger@v1
+        id: detect-trigger
+        with:
+          keyword: "[skip-ci]"
+
+  tests:
+    name: ${{ matrix.os }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    needs: detect-ci-trigger
+    if: needs.detect-ci-trigger.outputs.triggered == 'false'
+    defaults:
+      run:
+        shell: bash -leo pipefail {0} {0}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for all branches and tags
+
+      - name: Setup environment
+        run: |
+          python -m pip install numpy pytest pytest-cov
+
+      - name: Install marray
+        run: |
+          python -m pip install --no-deps -e .
+
+      - name: Import marray
+        run: |
+          python -c "import marray"
+
+      - name: Run tests
+        run: |
+          python -m pytest --cov=marray

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup environment
         run: |
-          python -m pip install numpy pytest pytest-cov
+          python -m pip install -r ci/requirements/environment.txt
 
       - name: Install marray
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,90 @@
+name: Upstream-dev CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    types: [opened, reopened, synchronize, labeled]
+  schedule:
+    - cron: "0 0 * * 1" # Mondays “At 00:00” UTC
+  workflow_dispatch: # allows you to trigger the workflow run manually
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-ci-trigger:
+    name: detect ci trigger
+    runs-on: ubuntu-latest
+    if: |
+      github.repository_owner == 'mdhaber' && github.event_name == 'pull_request'
+    outputs:
+      triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: xarray-contrib/ci-trigger@v1
+        id: detect-trigger
+        with:
+          keyword: "[test-upstream]"
+
+  tests:
+    name: upstream-dev
+    runs-on: ubuntu-latest
+    needs: detect-ci-trigger
+    if: |
+      always()
+      && (
+        (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        || needs.detect-ci-trigger.outputs.triggered == 'true'
+        || contains(github.event.pull_request.labels.*.name, 'run-upstream')
+      )
+
+    defaults:
+      run:
+        shell: bash -leo pipefail {0} {0}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        run: |
+          python -m pip install -r ci/requirements/environment.txt
+
+      - name: Install upstream versions
+        run: |
+          bash ci/install-upstream-wheels.sh
+
+      - name: Install marray
+        run: |
+          python -m pip install --no-deps -e .
+
+      - name: Import marray
+        run: |
+          python -c "import marray"
+
+      - name: Run tests
+        if: success()
+        id: run-tests
+        run: |
+          python -m pytest --report-log output-${{ matrix.python-version }}-log.jsonl
+
+      - name: Generate and publish a failure report
+        if: |
+          failure()
+          && steps.run-tests.outcome == 'failure'
+          && github.event_name == 'schedule'
+          && github.repository_owner == 'xarray-contrib'
+        uses: xarray-contrib/issue-from-pytest-log@v1
+        with:
+          log-path: output-${{ matrix.python-version }}-log.jsonl

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,36 @@
+name: Upload Python Package on PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/marray
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install publish dependencies
+        run: python -m pip install build
+
+      - name: Build package
+        run: python -m build . -o py_dist
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: py_dist/

--- a/ci/install-nightly-wheels.sh
+++ b/ci/install-nightly-wheels.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+python -m pip uninstall numpy
+
+python -m pip install --upgrade --no-deps --pre \
+    -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+    numpy

--- a/ci/requirements/environment.txt
+++ b/ci/requirements/environment.txt
@@ -1,0 +1,4 @@
+numpy
+array-api-strict
+pytest
+pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,11 @@ known-first-party = ["marray"]
 [tool.ruff.lint.flake8-tidy-imports]
 # Disallow all relative imports.
 ban-relative-imports = "all"
+
+[tool.coverage.run]
+source = ["marray"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,8 @@ branch = true
 [tool.coverage.report]
 show_missing = true
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error:::marray.*",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
 dependencies = ["numpy"]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,12 @@ name = "marray"
 authors = [{name = "Matt Haberland", email = "mhaberla@calpoly.edu"}]
 readme = "README.md"
 license = {file = "LICENSE"}
-classifiers = ["License :: OSI Approved :: MIT License"]
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
 dynamic = ["version", "description"]
 dependencies = ["numpy"]
 requires-python = ">=3.10"


### PR DESCRIPTION
This configures the following CI jobs (mostly following `xarray`'s CI setup, since that's what I'm most familiar with):
- `ci.yml`: main CI, runs on the combination of ubuntu, macos and windows with the supported python versions, according to SPEC0 (3.10, 3.11, 3.12). No 3.13, yet, but should be very easy to add.
- `nightly.yml`: periodically run the tests with upstream versions of the dependencies to get an early warning system for when upstream changes would break this package (uses [xarray-contrib/issue-from-pytest-log](https://github.com/xarray-contrib/issue-from-pytest-log) to open an issue whenever something fails)
- `pypi.yml`: allow using github releases to publish to PyPI. It does so by registering the action in PyPI, then using short-lived tokens to authenticate and push packages (see [trusted publishers](https://docs.pypi.org/trusted-publishers/)). Will need some setup like a `pypi` github environment, though.

There's a couple of tricks I'm using, one of which is to allow using `[skip-ci]` in the commit message's subject line to skip the main CI, and `[test-upstream]` to run the nightly CI on a certain commit; use the `run-upstream` tag to run the nightly CI for all pushes to a PR (if you don't agree with any of the names this should be easy to change, the action that scans the commit message takes the exact string as a parameter).