### PR TITLE
TST: test sorting functions

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -256,29 +256,6 @@ def masked_array(xp):
     # To be written:
     # take
 
-    def xp_take_along_axis(arr, indices, axis):
-        # This is just for regular arrays; not masked arrays
-        arr = xp_swapaxes(arr, axis, -1)
-        indices = xp_swapaxes(indices, axis, -1)
-
-        m = arr.shape[-1]
-        n = indices.shape[-1]
-
-        shape = list(arr.shape)
-        shape.pop(-1)
-        shape = shape + [n,]
-
-        arr = xp.reshape(arr, (-1,))
-        indices = xp.reshape(indices, (-1, n))
-
-        offset = (xp.arange(indices.shape[0]) * m)[:, xp.newaxis]
-        indices = xp.reshape(offset + indices, (-1,))
-
-        out = arr[indices]
-        out = xp.reshape(out, shape)
-        return xp_swapaxes(out, axis, -1)
-    mod._xp_take_along_axis = xp_take_along_axis
-
     ## Inspection ##
     # Included with dtype functions above
 
@@ -340,13 +317,6 @@ def masked_array(xp):
     for name in manip_names:
         setattr(mod, name, get_manip_fun(name))
     mod.broadcast_arrays = lambda *arrays: get_manip_fun('broadcast_arrays')(arrays)
-
-    # This is just for regular arrays; not masked arrays
-    def xp_swapaxes(arr, axis1, axis2):
-        axes = list(range(arr.ndim))
-        axes[axis1], axes[axis2] = axes[axis2], axes[axis1]
-        return xp.permute_dims(arr, axes)
-    mod.xp_swapaxes = xp_swapaxes
 
     ## Searching Functions
     # To be added


### PR DESCRIPTION
Also remove `xp_take_along_axis` and `xp_swapaxes`, which aren't needed here. `take_along_axis` will be in the next version of the standard anyway, which will make it much easier to implement.