### PR TITLE
TST: test scalar conversions, indexing, and dlpack methods

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -125,6 +125,19 @@ def masked_array(xp):
         def mT(self):
             return MaskedArray(self.data.mT, self.mask.mT)
 
+        # dlpack
+        def __dlpack_device__(self):
+            return self.data.__dlpack_device__()
+
+        def __dlpack__(self):
+            # really not sure how to define this
+            return self.data.__dlpack__()
+
+        def to_device(self, device, /, *, stream=None):
+            self._data = self._data.to_device(device, stream=stream)
+            self._mask = self._mask.to_device(device, stream=stream)
+
+
     ## Methods ##
 
     # Methods that return the result of a unary operation as an array
@@ -171,10 +184,6 @@ def masked_array(xp):
             self.call_super_method(name, other)
             return self
         setattr(MaskedArray, name, fun)
-
-    # To be added
-    # __dlpack__, __dlpack_device__
-    # to_device?
 
     def info(x):
         xp = x._xp

--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -199,11 +199,12 @@ def masked_array(xp):
             raise NotImplementedError()
 
         data = getattr(obj, 'data', obj)
+        data = xp.asarray(data, dtype=dtype, device=device, copy=copy)
+
         mask = (getattr(obj, 'mask', xp.full(data.shape, False))
                 if mask is None else mask)
-
-        data = xp.asarray(data, dtype=dtype, device=device, copy=copy)
         mask = xp.asarray(mask, dtype=dtype, device=device, copy=copy)
+
         return MaskedArray(data, mask=mask)
     mod.asarray = asarray
 

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -97,7 +97,7 @@ bitwise_methods_binary = {'bitwise_and': lambda x, y: x.__and__(y),
 scalar_conversions = {bool: True, int: 10, float: 1.5, complex: 1.5 + 2.5j}
 
 # tested in test_dlpack
-# __dlpack__, __dlpack_device__, __to_device__
+# __dlpack__, __dlpack_device__, to_device
 # tested in test_indexing
 # __getitem__, __index__, __setitem__,
 
@@ -261,8 +261,14 @@ def test_indexing(xp=strict):
     assert x[2].mask == True
 
 
-# tested in test_dlpack
-# __dlpack__, __dlpack_device__, __to_device__
+def test_dlpack(xp=strict, seed=None):
+    # This is a placeholder for a real test when there is a real implementation
+    mxp = marray.masked_array(xp)
+    marrays, _, seed = get_arrays(1, seed=seed)
+    assert isinstance(marrays[0].__dlpack__(), type(marrays[0].data.__dlpack__()))
+    assert marrays[0].__dlpack_device__() == marrays[0].data.__dlpack_device__()
+    marrays[0].to_device('cpu')
+
 
 @pytest.mark.parametrize("dtype", dtypes_integral + dtypes_real)
 @pytest.mark.parametrize("f", comparison_binary + comparison_methods_binary)


### PR DESCRIPTION
See gh-24 for issue about using a masked array as an index. For now, we don't test the behavior, really, except by explictly converting a 0-D masked array to an index.

For the dlpack methods:
- I think `__dlpack_device__` is what we want, and the simple test is probably fine, but this brings to mind that we might want to require `assert data.device == mask.device`.
- There are currently a lot of issues with DLPack (e.g. see gh-21890 for some information and links), so I don't think it's a big problem if we don't have a proper implementation of `__dlpack__` or good test of `todevice` right now. Opened gh-25 as a reminder.