### PR TITLE
ENH: make `masked_array` function return a proper module

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -4,6 +4,7 @@ Masked versions of array API compatible arrays
 
 __version__ = "0.0.4"
 
+import types, sys
 import numpy as np  # temporarily used in __repr__ and __str__
 
 
@@ -183,10 +184,8 @@ def masked_array(xp):
         else:
             return xp.finfo(x.dtype)
 
-    class module:
-        pass
-
-    mod = module()
+    mod = types.ModuleType('mxp')
+    sys.modules['mxp'] = mod
 
     ## Constants ##
     constant_names = ['e', 'inf', 'nan', 'newaxis', 'pi']

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -429,6 +429,13 @@ def test_statistical_array(f_name, keepdims, xp=np, dtype='float64', seed=None):
 # Sorting functions
 # __array_namespace__
 
+
+def test_import(xp=np):
+    mxp = marray.masked_array(xp)
+    from mxp import asarray
+    asarray(10, mask=True)
+
+
 def test_test():
     seed = 149020664425889521094089537542803361848
     # test_statistical_array('argmin', True, seed=seed)


### PR DESCRIPTION
Currently, the `marrray` package contains exactly one thing: the `masked_array` function. (gh-17 suggests renaming `masked_array` to `get_marray`, which would make some of the code below a bit more readable.)

This PR makes `masked_array` return a real Python module, whereas before it was just a generic `object` with attributes.

Now, when executed as a script, this works:
```python3
import numpy as xp
import marray
mxp = marray.masked_array(xp)
from mxp import asarray
asarray([1, 2, 3], mask=True)
```

Currently, the name of the module `mxp` is hard-coded. This doesn't work.
```python3
mod = marray.masked_array(xp)
from mod import asarray
# ModuleNotFoundError: No module named 'xp'
```

Perhaps `masked_array` could accept an argument:
```python3
mod = marray.masked_array(xp, 'mod')
# mod = marray.get_marray(xp, module_name='mod')
from mod import asarray
```

This is something we can revisit and make as fancy as we want. The only thing I wanted to do here was make the object returned by `masked_array` a real module.
