### PR TITLE
MAINT: avoid UserWarnings

### DIFF
--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -68,8 +68,12 @@ def assert_comparison(res, ref, seed, xp, comparison, **kwargs):
     ref_mask = ref.mask.__array_namespace__().broadcast_to(ref.mask, ref.data.shape)
     try:
         strict = kwargs.pop('strict', True)
-        comparison(res.data[~res.mask], ref.data[~ref_mask], strict=strict, **kwargs)
-        comparison(res.mask, ref_mask, strict=True, **kwargs)
+        res_data = np.asarray(res.data[~res.mask])
+        res_mask = np.asarray(res.mask)
+        ref_data = np.asarray(ref.data[~ref_mask])
+        ref_mask = np.asarray(ref_mask)
+        comparison(res_data, ref_data, strict=strict, **kwargs)
+        comparison(res_mask, ref_mask, strict=True, **kwargs)
     except AssertionError as e:
         raise AssertionError(seed) from e
 

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -508,7 +508,7 @@ def test_elementwise_unary(f_name, dtype, xp, seed=None):
     f = getattr(mxp, f_name)
     f2 = getattr(xp, f_name)
     res = f(marrays[0])
-    ref_data = f2(masked_arrays[0].data)
+    ref_data = f2(xp.asarray(masked_arrays[0].data))
     ref_mask = masked_arrays[0].mask
     ref = np.ma.masked_array(ref_data, mask=ref_mask)
     assert_equal(res, ref, xp=xp, seed=seed)

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -68,12 +68,8 @@ def assert_comparison(res, ref, seed, xp, comparison, **kwargs):
     ref_mask = ref.mask.__array_namespace__().broadcast_to(ref.mask, ref.data.shape)
     try:
         strict = kwargs.pop('strict', True)
-        res_data = np.asarray(res.data[~res.mask])
-        res_mask = np.asarray(res.mask)
-        ref_data = np.asarray(ref.data[~ref_mask])
-        ref_mask = np.asarray(ref_mask)
-        comparison(res_data, ref_data, strict=strict, **kwargs)
-        comparison(res_mask, ref_mask, strict=True, **kwargs)
+        comparison(res.data[~res.mask], ref.data[~ref_mask], strict=strict, **kwargs)
+        comparison(res.mask, ref_mask, strict=True, **kwargs)
     except AssertionError as e:
         raise AssertionError(seed) from e
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    "error:::marray.*",
+    "error",
     "ignore:invalid value encountered:RuntimeWarning",
     "ignore:divide by zero encountered:RuntimeWarning",
     "ignore:overflow encountered:RuntimeWarning",


### PR DESCRIPTION
We're getting a ton of warnings in CI that I'm not seeing locally:
<details>

```shell
=============================== warnings summary ===============================
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-bool-logical_not]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:711: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _boolean_dtypes:

marray/tests/test_marray.py: 12 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:30: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _numeric_dtypes:

marray/tests/test_marray.py: 10 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:261: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _real_numeric_dtypes:

marray/tests/test_marray.py: 10 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:482: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _real_numeric_dtypes:

marray/tests/test_marray.py: 12 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:570: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _numeric_dtypes:

marray/tests/test_marray.py: 12 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:581: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _numeric_dtypes:

marray/tests/test_marray.py: 12 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:592: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _numeric_dtypes:

marray/tests/test_marray.py: 12 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:803: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _numeric_dtypes:

marray/tests/test_marray.py: 12 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:842: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _numeric_dtypes:

marray/tests/test_marray.py: 12 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:908: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _numeric_dtypes:

marray/tests/test_marray.py: 12 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:919: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _numeric_dtypes:

marray/tests/test_marray.py: 12 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:966: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _numeric_dtypes:

marray/tests/test_marray.py: 10 warnings
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:1026: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _real_numeric_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-acos]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-acos]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-acos]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-acos]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:42: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-acosh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-acosh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-acosh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-acosh]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:54: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-asin]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-asin]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-asin]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-asin]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:83: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-asinh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-asinh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-asinh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-asinh]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:[95](https://github.com/mdhaber/marray/actions/runs/12113728195/job/33769158259#step:7:96): UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-atan]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-atan]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-atan]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-atan]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:107: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-atanh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-atanh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-atanh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-atanh]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:136: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-cos]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-cos]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-cos]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-cos]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:408: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-cosh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-cosh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-cosh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-cosh]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:419: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-exp]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-exp]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-exp]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-exp]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:460: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-expm1]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-expm1]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-expm1]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-expm1]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:471: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-log]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-log]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-log]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-log]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:635: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-log1p]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-log1p]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-log1p]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-log1p]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:646: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-log2]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-log2]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-log2]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-log2]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:657: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-log10]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-log10]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-log10]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-log10]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:668: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-signbit]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-signbit]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:933: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _real_floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-sin]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-sin]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-sin]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-sin]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:944: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-sinh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-sinh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-sinh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-sinh]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:955: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-sqrt]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-sqrt]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-sqrt]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-sqrt]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:977: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-tan]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-tan]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-tan]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-tan]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:1004: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float32-tanh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-float64-tanh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-tanh]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-tanh]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:1015: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-conj]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-conj]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:381: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _complex_floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-imag]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-imag]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:559: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _complex_floating_dtypes:

marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex64-real]
marray/tests/test_marray.py::test_elementwise_unary[array_api_strict-complex128-real]
  /opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/site-packages/array_api_strict/_elementwise_functions.py:870: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
    if x.dtype not in _complex_floating_dtypes:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform linux, python 3.11.10-final-0 ----------
Name                          Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------
marray/__init__.py              323     25     48      2    92%   [96](https://github.com/mdhaber/marray/actions/runs/12113728195/job/33769158259#step:7:97)-101, 105, 108, 187->190, 217, 385-389, 392-397, 412-418
marray/tests/test_marray.py     578      3     92      2    99%   62->66, 70-71, 93
-------------------------------------------------------------------------
TOTAL                           901     28    140      4    97%

========= 5061 passed, 60 skipped, 162 xfailed, 223 warnings in 20.97s =========
```

</details>

This PR tries to avoid them.
