### PR TITLE
fix typo in tutorial

### DIFF
--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -287,7 +287,7 @@
     {
       "cell_type": "code",
       "source": [
-        "mxp.sum(x)  # 1 and 3 were masked"
+        "mxp.sum(x)  # 2 and 4 were masked"
       ],
       "metadata": {
         "colab": {


### PR DESCRIPTION
<img width="353" alt="image" src="https://github.com/user-attachments/assets/17db8d0e-d12e-4109-a113-0d5c5ea588bf" />
