### PR TITLE
MAINT: unique_: correct and test set functions

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -437,6 +437,8 @@ def get_namespace(xp):
                 raise NotImplementedError(message)
             x = asarray(x)
             data = xp.asarray(x.data, copy=True)
+            # Replace masked elements with a sentinel value: they are all treated as
+            # the same as one another and distinct from all non-masked values.
             data[x.mask] = sentinel
             fun = getattr(xp, name)
             res = fun(data)

--- a/tools/xp-tests-xfails.txt
+++ b/tools/xp-tests-xfails.txt
@@ -36,11 +36,7 @@ array_api_tests/test_has_names.py::test_has_names[linalg-tensordot]
 array_api_tests/test_has_names.py::test_has_names[linalg-trace]
 array_api_tests/test_has_names.py::test_has_names[linalg-vecdot]
 array_api_tests/test_has_names.py::test_has_names[linalg-vector_norm]
-# marray does not correctly define `unique_` functions or `__dlpack__ yet`
-array_api_tests/test_set_functions.py::test_unique_all
-array_api_tests/test_set_functions.py::test_unique_counts
-array_api_tests/test_set_functions.py::test_unique_inverse
-array_api_tests/test_set_functions.py::test_unique_values
+# marray does not correctly define `__dlpack__ yet`
 array_api_tests/test_signatures.py::test_array_method_signature[__dlpack__]
 # flaky on macos
 array_api_tests/test_operators_and_elementwise_functions.py::test_sqrt


### PR DESCRIPTION
Closes gh-34. Removes array-ai-tests skips of `unique_` functions.

As an enhancement, we could automatically promote dtypes and/or exhaustively look for another sentinel value, but this is enough to consider the set functions to be implemented.