### PR TITLE
ENH: modify namespace based on backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ Install with `pip`.
 pip install marray
 ```
 
-The only public function is `get_namespace`:
+Use the `from...import...as` syntax to get a masked array namespace.
 
 ```python3
-import numpy as xp  # use any Array API compatible library, installed separately
-import marray
-mxp = marray.get_namespace(xp)
+# use with any Array API compatible library, installed separately
+from marray import numpy as mxp
+import numpy as xp  # optional (if the non-masked namespace is desired)
 ```
 
 The resulting `mxp` namespace has all the features of `xp` that are specified
 in the Array API standard, but they are modified to be mask-aware. Typically, the
-signatures of functions in the `mxp` namespace match those in the `xp` namespace;
+signatures of functions in the `mxp` namespace match those in the standard;
 the one notable exception is the addition of a `mask` keyword argument of `asarray`.
 
 ```python3
@@ -39,4 +39,4 @@ Documentation provided by attributes of `xp` are exposed in the `mxp`
 namespace and are accessible via `help`. For more information, please see
 [the tutorial](https://mdhaber.github.io/marray/tutorial.html).
 
-[^1]: The MArray logo is a nod to NumPy, but MArray is not affiliated with the NumPy project.
+[^1]: The MArray logo is a nod to NumPy's logo, but MArray is not affiliated with the NumPy project.

--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -15,21 +15,21 @@ import types
 def __getattr__(name):
     try:
         xp = importlib.import_module(name)
-        mod = get_namespace(xp)
+        mod = _get_namespace(xp)
         sys.modules[f"marray.{name}"] = mod
         return mod
     except ModuleNotFoundError as e:
         raise AttributeError(str(e))
 
 
-def get_namespace(xp):
+def _get_namespace(xp):
     """Returns a masked array namespace for an Array API Standard compatible backend
 
     Examples
     --------
     >>> import numpy as xp
-    >>> from marray import get_namespace
-    >>> mxp = get_namespace(xp)
+    >>> from marray import _get_namespace
+    >>> mxp = _get_namespace(xp)
     >>> A = mxp.eye(3)
     >>> A.mask[0, ...] = True
     >>> x = mxp.asarray([1, 2, 3], mask=[False, False, True])

--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -207,8 +207,9 @@ def get_namespace(xp):
             return self
         setattr(MArray, name, fun)
 
-    mod = types.ModuleType('mxp')
-    sys.modules['mxp'] = mod
+    mod_name = f'mxp({xp.__name__})'
+    mod = types.ModuleType(mod_name)
+    sys.modules['mod_name'] = mod
 
     mod.MArray = MArray
 

--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -6,9 +6,20 @@ __version__ = "0.0.5"
 
 import collections
 import dataclasses
+import importlib
 import inspect
 import sys
 import types
+
+
+def __getattr__(name):
+    try:
+        xp = importlib.import_module(name)
+        mod = get_namespace(xp)
+        sys.modules[f"marray.{name}"] = mod
+        return mod
+    except ModuleNotFoundError as e:
+        raise AttributeError(str(e))
 
 
 def get_namespace(xp):
@@ -207,9 +218,9 @@ def get_namespace(xp):
             return self
         setattr(MArray, name, fun)
 
-    mod_name = f'mxp({xp.__name__})'
+    mod_name = f'marray.{xp.__name__})'
     mod = types.ModuleType(mod_name)
-    sys.modules['mod_name'] = mod
+    sys.modules[mod_name] = mod
 
     mod.MArray = MArray
 

--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -218,7 +218,7 @@ def get_namespace(xp):
             return self
         setattr(MArray, name, fun)
 
-    mod_name = f'marray.{xp.__name__})'
+    mod_name = f'marray.{xp.__name__}'
     mod = types.ModuleType(mod_name)
     sys.modules[mod_name] = mod
 

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -21,7 +21,7 @@ dtypes_all = dtypes_boolean + dtypes_integral + dtypes_real + dtypes_complex
 
 
 def get_arrays(n_arrays, *, dtype, xp, ndim=(1, 4), seed=None):
-    xpm = marray.get_namespace(xp)
+    xpm = marray._get_namespace(xp)
 
     entropy = np.random.SeedSequence(seed).entropy
     rng = np.random.default_rng(entropy)
@@ -240,7 +240,7 @@ def test_array_binary(f, dtype, xp, seed=None):
 @pytest.mark.parametrize('xp', xps)
 def test_bitwise_unary(f_name_fun, dtype, xp, seed=None):
     f_name, f = f_name_fun
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, masked_arrays, seed = get_arrays(1, dtype=dtype, xp=xp, seed=seed)
 
     res = f(~marrays[0])
@@ -260,7 +260,7 @@ def test_bitwise_unary(f_name_fun, dtype, xp, seed=None):
                           "Only integer dtypes are allowed in "])
 def test_bitwise_binary(f_name_fun, dtype, xp, seed=None):
     f_name, f = f_name_fun
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, masked_arrays, seed = get_arrays(2, dtype=dtype, xp=xp, seed=seed)
 
     res = f(marrays[0], marrays[1])
@@ -276,7 +276,7 @@ def test_bitwise_binary(f_name_fun, dtype, xp, seed=None):
 @pytest.mark.parametrize('mask', [False, True])
 @pytest.mark.parametrize('xp', xps)
 def test_scalar_conversion(type_val, mask, xp):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     type, val = type_val
     x = mxp.asarray(val)
     assert type(x) == val
@@ -293,7 +293,7 @@ def test_indexing(xp):
     # This does not make them easy to test exhaustively, but it does make
     # them easy to fix if a shortcoming is identified. Include a very basic
     # test for now, and improve as needed.
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     x = mxp.asarray(xp.arange(3), mask=[False, True, False])
 
     # Test `__setitem__`/`__getitem__` roundtrip
@@ -327,7 +327,7 @@ def test_indexing(xp):
 @pytest.mark.parametrize('xp', xps)
 def test_dlpack(dtype, xp, seed=None):
     # This is a placeholder for a real test when there is a real implementation
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, _, seed = get_arrays(1, dtype=dtype, xp=xp, seed=seed)
     assert isinstance(marrays[0].__dlpack__(), type(marrays[0].data.__dlpack__()))
     assert marrays[0].__dlpack_device__() == marrays[0].data.__dlpack_device__()
@@ -382,7 +382,7 @@ def test_inplace(f, arg2_masked, dtype, xp, seed=None):
 @pass_exceptions(allowed=["Only numeric dtypes are allowed in matmul"])
 def test_inplace_array_binary(f, dtype, xp, seed=None):
     # very restrictive operator -> limited test
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     rng = np.random.default_rng(seed)
     data = (rng.random((3, 10, 10))*10).astype(dtype)
     mask = rng.random((3, 10, 10)) > 0.5
@@ -425,7 +425,7 @@ def test_rarithmetic_binary(f, dtype, xp, type_, seed=None):
 @pass_exceptions(allowed=["Only numeric dtypes are allowed in __matmul__"])
 def test_rarray_binary(dtype, xp, seed=None):
     # very restrictive operator -> limited test
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     rng = np.random.default_rng(seed)
     data = (rng.random((3, 10, 10))*10).astype(dtype)
     mask = rng.random((3, 10, 10)) > 0.5
@@ -467,7 +467,7 @@ def test_attributes(dtype, xp, seed=None):
 
 @pytest.mark.parametrize('xp', xps)
 def test_constants(xp):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     assert mxp.e == xp.e
     assert mxp.inf == xp.inf
     assert np.isnan(mxp.nan) == np.isnan(xp.nan)
@@ -478,7 +478,7 @@ def test_constants(xp):
 @pytest.mark.parametrize("f", data_type + inspection + version)
 @pytest.mark.parametrize('xp', xps)
 def test_dtype_funcs_inspection(f, xp):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     getattr(mxp, f) is getattr(xp, f)
 
 
@@ -487,7 +487,7 @@ def test_dtype_funcs_inspection(f, xp):
 def test_dtypes(dtype, xp):
     if xp == np:
         pytest.xfail("NumPy fails... unclear whether NumPy follows standard here.")
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     getattr(mxp, dtype).__eq__(getattr(xp, dtype))
 
 
@@ -504,7 +504,7 @@ def test_dtypes(dtype, xp):
                           "Only boolean dtypes are allowed",
                           "Only complex floating-point dtypes are allowed"])
 def test_elementwise_unary(f_name, dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, masked_arrays, seed = get_arrays(1, dtype=dtype, xp=xp, seed=seed)
     f = getattr(mxp, f_name)
     f2 = getattr(xp, f_name)
@@ -527,7 +527,7 @@ def test_elementwise_unary(f_name, dtype, xp, seed=None):
                           "Only numeric dtypes are allowed",
                           "Only boolean dtypes are allowed",])
 def test_elementwise_binary(f_name, dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, masked_arrays, seed = get_arrays(2, dtype=dtype, xp=xp, seed=seed)
     f = getattr(mxp, f_name)
     f2 = getattr(np, f_name)
@@ -550,7 +550,7 @@ def test_statistical_array(f_name, keepdims, xp, dtype, seed=None):
         # should fix this and ensure strict check at the end
         pytest.skip("`np.ma` can't provide reference due to numpy/numpy#27885")
 
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, masked_arrays, seed = get_arrays(1, dtype=dtype, xp=xp, seed=seed)
     rng = np.random.default_rng(seed)
     axes = list(range(marrays[0].ndim))
@@ -595,7 +595,7 @@ def test_statistical_array(f_name, keepdims, xp, dtype, seed=None):
 @pass_exceptions(allowed=[r"arange() is only supported for booleans when"])
 def test_creation(f_name, args, kwargs, dtype, xp, seed=None):
     dtype = getattr(xp, dtype)
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     f_xp = getattr(xp, f_name)
     f_mxp = getattr(mxp, f_name)
     if f_name.endswith('like'):
@@ -614,7 +614,7 @@ def test_creation(f_name, args, kwargs, dtype, xp, seed=None):
 @pytest.mark.parametrize("dtype", dtypes_all + [None])
 @pytest.mark.parametrize('xp', xps)
 def test_creation_like(f_name, dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     f_mxp = getattr(mxp, f_name)
     f_np = getattr(np, f_name)  # np.ma doesn't have full_like
     args = (2,) if f_name == "full_like" else ()
@@ -633,7 +633,7 @@ def test_creation_like(f_name, dtype, xp, seed=None):
 @pytest.mark.parametrize('dtype', dtypes_all)
 @pytest.mark.parametrize('xp', xps)
 def test_tri(f_name, dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     f_xp = getattr(xp, f_name)
     f_mxp = getattr(mxp, f_name)
     marrays, _, seed = get_arrays(1, ndim=(2, 4), dtype=dtype, xp=xp, seed=seed)
@@ -649,7 +649,7 @@ def test_tri(f_name, dtype, xp, seed=None):
 @pytest.mark.parametrize('dtype', dtypes_all)
 @pytest.mark.parametrize('xp', xps)
 def test_meshgrid(indexing, dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     rng = np.random.default_rng(seed)
     n = rng.integers(1, 4)
     marrays, masked_arrays, seed = get_arrays(n, ndim=1, dtype=dtype, xp=xp, seed=seed)
@@ -667,7 +667,7 @@ def test_meshgrid(indexing, dtype, xp, seed=None):
 @pytest.mark.parametrize('dtype', dtypes_integral + dtypes_real)
 @pytest.mark.parametrize('xp', xps)
 def test_searchsorted(side, dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
 
     rng = np.random.default_rng(seed)
     n = 20
@@ -711,7 +711,7 @@ def test_searchsorted(side, dtype, xp, seed=None):
 @pytest.mark.parametrize('dtype', dtypes_all)
 @pytest.mark.parametrize('xp', xps)
 def test_where(dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, masked_arrays, seed = get_arrays(2, dtype=dtype, xp=xp, seed=seed)
     rng = np.random.default_rng(seed)
     cond = rng.random(marrays[0].shape) > 0.5
@@ -723,7 +723,7 @@ def test_where(dtype, xp, seed=None):
 @pytest.mark.parametrize('dtype', dtypes_all)
 @pytest.mark.parametrize('xp', xps)
 def test_nonzero(dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, masked_arrays, seed = get_arrays(1, dtype=dtype, xp=xp, seed=seed)
     x, y = marrays[0], masked_arrays[0]
     rng = np.random.default_rng(seed)
@@ -757,7 +757,7 @@ def test_nonzero(dtype, xp, seed=None):
 @pytest.mark.parametrize('dtype', dtypes_all)
 @pytest.mark.parametrize('xp', xps)
 def test_manipulation(f_name, n_arrays, n_dims, args, kwargs, dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, _, seed = get_arrays(n_arrays, ndim=n_dims, dtype=dtype, xp=xp, seed=seed)
     if f_name in {'broadcast_to', 'squeeze'}:
         original_shape = marrays[0].shape
@@ -792,7 +792,7 @@ def test_manipulation(f_name, n_arrays, n_dims, args, kwargs, dtype, xp, seed=No
 @pytest.mark.parametrize('copy', [False, True])
 @pytest.mark.parametrize('xp', xps)
 def test_astype(dtype_in, dtype_out, copy, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, masked_arrays, seed = get_arrays(1, dtype=dtype_in, xp=xp, seed=seed)
 
     res = mxp.astype(marrays[0], getattr(xp, dtype_out), copy=copy)
@@ -809,7 +809,7 @@ def test_astype(dtype_in, dtype_out, copy, xp, seed=None):
 
 @pytest.mark.parametrize('xp', xps)
 def test_asarray_device(xp):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     message = "`device` argument is not implemented"
     with pytest.raises(NotImplementedError, match=message):
         mxp.asarray(xp.asarray([1, 2, 3]), device='coconut')
@@ -819,7 +819,7 @@ def test_asarray_device(xp):
 @pytest.mark.parametrize('xp', xps)
 @pass_exceptions(allowed=["Only real numeric dtypes are allowed"])
 def test_clip(dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, masked_arrays, seed = get_arrays(3, dtype=dtype, xp=xp, seed=seed)
     min = mxp.minimum(marrays[1], marrays[2])
     max = mxp.maximum(marrays[1], marrays[2])
@@ -835,7 +835,7 @@ def test_clip(dtype, xp, seed=None):
 @pytest.mark.parametrize('dtype', dtypes_all)
 @pytest.mark.parametrize('xp', xps)
 def test_set(f_name, dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, _, seed = get_arrays(1, dtype=dtype, xp=xp, seed=seed)
     f_mxp = getattr(mxp, f_name)
 
@@ -882,7 +882,7 @@ def test_set(f_name, dtype, xp, seed=None):
 @pytest.mark.parametrize('dtype', dtypes_real + dtypes_integral)
 @pytest.mark.parametrize('xp', xps)
 def test_sorting(f_name, descending, stable, dtype, xp, seed=None):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     marrays, masked_arrays, seed = get_arrays(1, dtype=dtype, xp=xp, seed=seed)
     f_mxp = getattr(mxp, f_name)
     f_xp = getattr(np.ma, f_name)
@@ -931,7 +931,7 @@ def test_sorting(f_name, descending, stable, dtype, xp, seed=None):
 
 @pytest.mark.parametrize('xp', xps)
 def test_array_namespace(xp):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     x = mxp.asarray([1, 2, 3])
     assert x.__array_namespace__() is mxp
     assert x.__array_namespace__("2023.12") is mxp
@@ -953,26 +953,26 @@ def test_import():
 
 @pytest.mark.parametrize('xp', xps)
 def test_str(xp):
-    mxp = marray.get_namespace(xp)
+    mxp = marray._get_namespace(xp)
     x = mxp.asarray(1, mask=True)
     ref = "MArray(1, True)"
     assert str(x) == ref
 
 def test_repr():
-    mxp = marray.get_namespace(strict)
+    mxp = marray._get_namespace(strict)
     x = mxp.asarray(1, mask=True)
     ref = ("MArray(\n    Array(1, dtype=array_api_strict.int64),"
            "\n    Array(True, dtype=array_api_strict.bool)\n)")
     assert repr(x) == ref
 
-    mxp = marray.get_namespace(np)
+    mxp = marray._get_namespace(np)
     x = mxp.asarray(1, mask=True)
     ref = "MArray(array(1), array(True))"
     assert repr(x) == ref
 
 def test_signature_docs():
     # Rough test that signatures were replaced where possible
-    mxp = marray.get_namespace(np)
+    mxp = marray._get_namespace(np)
     assert mxp.sum.__signature__ == inspect.signature(np.sum)
     assert np.sum.__doc__ in mxp.sum.__doc__
 

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -940,11 +940,16 @@ def test_array_namespace(xp):
         x.__array_namespace__("shrubbery")
 
 
-# @pytest.mark.parametrize('xp', xps)
-# def test_import(xp):
-#     mxp = marray.get_namespace(xp)  # noqa: F841
-#     from mxp import asarray
-#     asarray(10, mask=True)
+def test_import():
+    from marray import numpy as mnp
+    assert mnp.__name__ == 'marray.numpy'
+    from marray.numpy import asarray
+    asarray(10, mask=True)
+
+    from marray import array_api_strict as mxp
+    assert mxp.__name__ == 'marray.array_api_strict'
+    from marray.array_api_strict import asarray
+    asarray(10, mask=True)
 
 @pytest.mark.parametrize('xp', xps)
 def test_str(xp):

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -940,11 +940,11 @@ def test_array_namespace(xp):
         x.__array_namespace__("shrubbery")
 
 
-@pytest.mark.parametrize('xp', xps)
-def test_import(xp):
-    mxp = marray.get_namespace(xp)  # noqa: F841
-    from mxp import asarray
-    asarray(10, mask=True)
+# @pytest.mark.parametrize('xp', xps)
+# def test_import(xp):
+#     mxp = marray.get_namespace(xp)  # noqa: F841
+#     from mxp import asarray
+#     asarray(10, mask=True)
 
 @pytest.mark.parametrize('xp', xps)
 def test_str(xp):

--- a/mybook/intro.md
+++ b/mybook/intro.md
@@ -10,17 +10,17 @@ Install with `pip`.
 pip install marray
 ```
 
-The only public function is `get_namespace`:
+Use the `from...import...as` syntax to get a masked array namespace.
 
 ```python3
-import numpy as xp  # use any Array API compatible library, installed separately
-import marray
-mxp = marray.get_namespace(xp)
+# use with any Array API compatible library, installed separately
+from marray import numpy as mxp
+import numpy as xp  # optional (if the non-masked namespace is desired)
 ```
 
 The resulting `mxp` namespace has all the features of `xp` that are specified
 in the Array API standard, but they are modified to be mask-aware. Typically, the
-signatures of functions in the `mxp` namespace match those in the `xp` namespace;
+signatures of functions in the `mxp` namespace match those in the standard;
 the one notable exception is the addition of a `mask` keyword argument of `asarray`.
 
 ```python3
@@ -35,4 +35,4 @@ Documentation provided by attributes of `xp` are exposed in the `mxp`
 namespace and are accessible via `help`. For more information, please see
 [the tutorial](https://colab.research.google.com/drive/1LaZCK3jvnf40qEjWEhqhhc5e8IWy7vuo?usp=sharing).
 
-[^1]: The MArray logo is a nod to NumPy, but MArray is not affiliated with the NumPy project.
+[^1]: The MArray logo is a nod to NumPy's logo, but MArray is not affiliated with the NumPy project.

--- a/mybook/tutorial.md
+++ b/mybook/tutorial.md
@@ -16,13 +16,11 @@ The rest of the tutorial will assume that we want to add masks to NumPy arrays. 
 # !pip install --upgrade numpy
 ```
 
-To create a version of the NumPy namespace with mask support, use `marray`'s only public attribute: `get_namespace`.
+To create a version of the NumPy namespace with mask support, use Python's `from...import...as` syntax.
 
 
 ```python
-import numpy as xp
-import marray
-mxp = marray.get_namespace(xp)
+from marray import numpy as mxp
 ```
 
 `mxp` exposes all the features of NumPy that are specified in the Array API standard, but adds masks support to them. For example:
@@ -172,6 +170,8 @@ mxp.zeros_like(y)
 `tril` and `triu` also preserve the mask of the indicated triangular portion of the argument.
 
 ```python
+import numpy as xp
+
 data = xp.ones((3, 3))
 mask = xp.zeros_like(data)
 mask[0, -1] = 1

--- a/tools/xp-tests.patch
+++ b/tools/xp-tests.patch
@@ -47,8 +47,8 @@ index 4e0c340..525782e 100644
 +
 +import marray
 +import array_api_strict
-+xp = marray.get_namespace(array_api_strict)
-+xp_name = "marray(array_api_strict)"
++xp = marray._get_namespace(array_api_strict)
++xp_name = "marray.array_api_strict"
  
  
  # If xp.bool is not available, like in some versions of NumPy and CuPy, try


### PR DESCRIPTION
Closes gh-59

@lucascolley I think this is what you had in mind for gh-59

```python3
import numpy as np
import array_api_strict as xp
import marray
mnp = marray.get_namespace(np)
mxp = marray.get_namespace(xp)
xp1 = mnp.arange(2).__array_namespace__()
xp1.__name__  # 'mxp(numpy)'
xp1.arange(2).data.__array_namespace__().__name__  # 'numpy'
xp2 = mxp.arange(3).__array_namespace__()
xp2.__name__  # 'mxp(array_api_strict)'
xp2.arange(3).data.__array_namespace__().__name__  # 'array_api_strict'
```

A problem is that this no longer works:
```
from mnp import asarray
# ModuleNotFoundError: No module named 'mnp'
from mxp(numpy) import asarray
# SyntaxError: invalid syntax
```
I don't think we can tell the name that the user assigns the namespace to, and I don't think we can have parentheses in the name we want to be able to import from. I can think of a few ways to address these issues, but I'll let you suggest first.

One (orthogonal) thought is that maybe the name should involve `marray` instead of `mxp`. Another is that maybe `get_namespace` should be `marray`. 