### PR TITLE
Fix logo URL; eliminate footnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <a href="https://mdhaber.github.io/marray">
-  <img src="https://github.com/mdhaber/marray/blob/main/mybook/logo.svg" alt="Logo" width="110" height="110" align="left" />
+  <img src="https://raw.githubusercontent.com/mdhaber/marray/main/mybook/logo.svg" alt="Logo. The MArray logo is a nod to NumPy's logo, but MArray is not affiliated with the NumPy project." width="110" height="110" align="left" />
 </a>
 
 [![PyPI Downloads](https://img.shields.io/pypi/dm/marray.svg?label=Pypi%20downloads)](https://pypi.org/project/marray/)
 
-MArray[^1] adds masks to your favorite
+MArray adds masks to your favorite
 [Python Array API Standard compatible](https://data-apis.org/array-api/latest/)
 array library.
 
@@ -44,5 +44,3 @@ and only obvious way to set the mask of an array.
 Documentation provided by attributes of `xp` are exposed in the `mxp`
 namespace and are accessible via `help`. For more information, please see
 [the tutorial](https://mdhaber.github.io/marray/tutorial.html).
-
-[^1]: The MArray logo is a nod to NumPy's logo, but MArray is not affiliated with the NumPy project.


### PR DESCRIPTION
This should fix gh-75 following the advice of oscal-compass/compliance-trestle#1628.
