### PR TITLE
Update version to 0.0.7

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -2,7 +2,7 @@
 Masked versions of array API compatible arrays
 """
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 import collections
 import dataclasses


### PR DESCRIPTION
I want to release again with `take_along_axis` to more easily investigate use of `marray` in https://github.com/scipy/scipy/pull/22352.