### PR TITLE
Update version to 0.0.8

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -2,7 +2,7 @@
 Masked versions of array API compatible arrays
 """
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 import collections
 import dataclasses


### PR DESCRIPTION
gh-81 is important to scipy/scipy#22393.