### PR TITLE
MAINT: speed up array binary operations

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -358,16 +358,15 @@ def _get_namespace(xp):
         def linalg_fun(x1, x2, /, **kwargs):
             x1 = asarray(x1)
             x2 = asarray(x2)
-            data1 = xp.asarray(x1.data, copy=True)
-            data2 = xp.asarray(x2.data, copy=True)
-            data1[x1.mask] = 0
-            data2[x2.mask] = 0
+            zero = xp.asarray(0)
+            data1 = xp.where(x1.mask, xp.asarray(0, dtype=x1.dtype), x1.data)
+            data2 = xp.where(x2.mask, xp.asarray(0, dtype=x2.dtype), x2.data)
             fun = getattr(xp, name)
             data = fun(data1, data2, **kwargs)
             # Strict array can't do arithmetic with booleans
             # mask = ~fun(~x1.mask, ~x2.mask)
-            mask = fun(xp.astype(~x1.mask, xp.uint64),
-                       xp.astype(~x2.mask, xp.uint64), **kwargs)
+            mask = fun(xp.astype(~x1.mask, xp.float32),
+                       xp.astype(~x2.mask, xp.float32), **kwargs)
             mask = ~xp.astype(mask, xp.bool)
             return MArray(data, mask)
         return linalg_fun


### PR DESCRIPTION
Matmul was very slow before!

```python3
import numpy as np
from marray import numpy as mnp
rng = np.random.default_rng(893458972872134)
shape = (1000, 1000)

data_a = rng.random(shape)
mask_a = rng.random(shape) > 0.5
data_b = rng.random(shape)
mask_b = rng.random(shape) > 0.5

xa = mnp.asarray(data_a.copy(), mask=mask_a.copy())
xb = mnp.asarray(data_b.copy(), mask=mask_b.copy())

ya = np.ma.masked_array(data_a.copy(), mask=mask_a.copy())
yb = np.ma.masked_array(data_b.copy(), mask=mask_b.copy())

# %timeit data_a @ data_b
# 8.2 ms ± 58.8 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# %timeit xa @ xb
# before: 1.5 s ± 44.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# after: 21.3 ms ± 1.36 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# %timeit ya @ yb
# 9.91 ms ± 241 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Still not as fast as NumPy masked array, but that might take a little more work. Let's start with this and improve further once gh-85 is ready.