### PR TITLE
MAINT: __getitem__/__setitem__: define behavior for boolean index with masked elements

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -129,7 +129,7 @@ def masked_namespace(xp):
             return MArray(self.data[i], (self.mask | key_mask)[i])
 
         def __getitem__(self, key):
-            if _is_boolean(key, xp):
+            if _is_boolean(key, xp) and getattr(key, 'size', 1) > 0:
                 return self._get_item_bool(key)
             key = self._validate_key(key)
             return MArray(self.data[key], self.mask[key])
@@ -145,7 +145,7 @@ def masked_namespace(xp):
             return self.data.__setitem__(i, other_data)
 
         def __setitem__(self, key, other):
-            if _is_boolean(key, xp):
+            if _is_boolean(key, xp) and getattr(key, 'size', 1) > 0:
                 return self._set_item_bool(key, other)
             key = self._validate_key(key)
             self.mask[key] = getattr(other, 'mask', False)

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -68,8 +68,10 @@ def assert_comparison(res, ref, seed, xp, comparison, **kwargs):
     ref_mask = ref.mask.__array_namespace__().broadcast_to(ref.mask, ref.data.shape)
     try:
         strict = kwargs.pop('strict', True)
-        comparison(res.data[~res.mask], ref.data[~ref_mask], strict=strict, **kwargs)
-        comparison(res.mask, ref_mask, strict=True, **kwargs)
+        comparison(np.asarray(res.data[~res.mask]),
+                   np.asarray(ref.data[~ref_mask]), strict=strict, **kwargs)
+        comparison(np.asarray(res.mask),
+                   np.asarray(ref_mask), strict=True, **kwargs)
     except AssertionError as e:
         raise AssertionError(seed) from e
 
@@ -303,7 +305,7 @@ def test_scalar_conversion(type_val, mask, xp):
 
 @pytest.mark.parametrize('xp', xps)
 def test_indexing(xp):
-    # The implementations of `__getitem__` and `__setitem__` are trivial.
+    # The implementations of `__getitem__` and `__setitem__` are simple.
     # This does not make them easy to test exhaustively, but it does make
     # them easy to fix if a shortcoming is identified. Include a very basic
     # test for now, and improve as needed.
@@ -345,6 +347,58 @@ def test_indexing(xp):
         i = mxp.ones(4, dtype=mxp.bool)
         j = i[..., i]
         assert mxp.all(i == j)
+
+@pytest.mark.parametrize('xp', xps)
+def test_boolean_indexing(xp, seed=None):
+    # The implementations of `__getitem__` and `__setitem__` are simple.
+    # This does not make them easy to test exhaustively, but it does make
+    # them easy to fix if a shortcoming is identified. Include a very basic
+    # test for now, and improve as needed.
+    mxp = marray.masked_namespace(xp)
+
+    x_val = np.arange(8)
+    x_mask = [False, False, False, False, True, True, True, True]
+    i_val = [False, False, True, True, False, False, True, True]
+    i_mask = [False, True, False, True, False, True, False, True]
+    x = mxp.asarray(x_val, mask=x_mask)
+    i = mxp.asarray(i_val, mask=i_mask)
+    j = ~i
+
+    # __getitem__
+    ref = mxp.asarray(x.data[i.data | i.mask], mask=(x.mask | i.mask)[i.data | i.mask])
+    assert_equal(x[i], ref, xp=xp, seed=seed)
+
+    ref = mxp.asarray(x.data[j.data | j.mask], mask=(x.mask | j.mask)[j.data | j.mask])
+    assert_equal(x[j], ref, xp=xp, seed=seed)
+
+    i_empty = mxp.asarray([], dtype=mxp.bool)  # special case
+    assert_equal(x[i_empty], x[1:1], xp=xp, seed=seed)
+
+    # __setitem__
+    x2 = mxp.asarray(x, copy=True)
+    x2[i] = 9
+    data = xp.asarray(x.data, copy=True)
+    mask = xp.asarray(x.mask, copy=True)
+    data[i.data & ~i.mask] = 9
+    mask[i.data & ~i.mask] = False
+    mask[i.mask] = True
+    ref = mxp.asarray(data, mask=mask)
+    assert_equal(x2, ref, xp=xp, seed=seed)
+
+    x2 = mxp.asarray(x, copy=True)
+    x2[i] = mxp.asarray(9, mask=True)
+    data = xp.asarray(x.data, copy=True)
+    mask = xp.asarray(x.mask, copy=True)
+    # Data assignment doesn't matter, since `other` is masked
+    mask[i.data] = True
+    mask[i.mask] = True
+    ref = mxp.asarray(data, mask=mask)
+    assert_equal(x2, ref, xp=xp, seed=seed)
+
+    x2 = mxp.asarray(x, copy=True)
+    x2[i_empty] = 9
+    x2[i_empty] = mxp.asarray(9, mask=True)
+    assert_equal(x2, x, xp=xp, seed=seed)
 
 
 # array-api-strict doesn't have take_along_axis yet, so xp=np

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -531,8 +531,9 @@ def test_boolean_indexing(xp, seed=None):
     ref = mxp.asarray(x.data[j.data | j.mask], mask=(x.mask | j.mask)[j.data | j.mask])
     assert_equal(x[j], ref, xp=xp, seed=seed)
 
-    i_empty = mxp.asarray([], dtype=mxp.bool)  # special case
-    assert_equal(x[i_empty], x[1:1], xp=xp, seed=seed)
+    if "torch" not in xp.__name__:  # torch doesn't implement this
+        i_empty = mxp.asarray([], dtype=mxp.bool)  # special case
+        assert_equal(x[i_empty], x[1:1], xp=xp, seed=seed)
 
     # __setitem__
     x2 = mxp.asarray(x, copy=True)
@@ -555,10 +556,11 @@ def test_boolean_indexing(xp, seed=None):
     ref = mxp.asarray(data, mask=mask)
     assert_equal(x2, ref, xp=xp, seed=seed)
 
-    x2 = mxp.asarray(x, copy=True)
-    x2[i_empty] = 9
-    x2[i_empty] = mxp.asarray(9, mask=True)
-    assert_equal(x2, x, xp=xp, seed=seed)
+    if "torch" not in xp.__name__:  # torch doesn't implement this
+        x2 = mxp.asarray(x, copy=True)
+        x2[i_empty] = 9
+        x2[i_empty] = mxp.asarray(9, mask=True)
+        assert_equal(x2, x, xp=xp, seed=seed)
 
 
 @pytest.mark.parametrize("dtype", dtypes_all)
@@ -1399,4 +1401,4 @@ def test_gh99(xp):
 def test_test():
     # dev tool to reproduce a particular failure of a `parametrize`d test
     seed = 91803015965563856304156452253329804912
-    test_nonzero("complex128", torch, seed=seed)
+    test_nonzero("complex128", np, seed=seed)


### PR DESCRIPTION
This implements "Option 4" from gh-24 regarding masked boolean indices.

`__getitem__` returns elements from `self` for each element of `key` that is True OR masked. Elements are masked wherever either `self` or `key` were masked.

`__setitem__` sets elements of `self` for each element of `key` that is True OR masked. Elements are masked wherever either `other` or `key` were masked.

```python3
import numpy as np
from marray import numpy as mxp
x_val = np.arange(8)
x_mask = [False, False, False, False, True, True, True, True]
i_val = [False, False, True, True, False, False, True, True]
i_mask = [False, True, False, True, False, True, False, True]
x = mxp.asarray(x_val, mask=x_mask)
i = mxp.asarray(i_val, mask=i_mask)
x = mxp.asarray(x_val, mask=x_mask)
other = 9

x             # [0 1 2 3 _ _ _ _]
i             # [0 _ 1 _ 0 _ 1 _]
x[i]          # [_ 2 _ _ _ _]
x[~i]         # [0 _ _ _ _ _]

x             # [0 1 2 3 _ _ _ _]
i             # [0 _ 1 _ 0 _ 1 _]
x[i] = other  # [0 _ 9 _ _ _ 9 _]

x = mxp.asarray(x_val, mask=x_mask)
other = mxp.asarray(9, mask=True)
x             # [0 1 2 3 _ _ _ _]
i             # [0 _ 1 _ 0 _ 1 _]
x[i] = other  # [0 _ _ _ _ _ _ _]
```