### PR TITLE
MAINT/TST: count: improve implementation, test

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -558,8 +558,7 @@ def masked_namespace(xp):
 
     def count(x, axis=None, keepdims=False):
         x = asarray(x)
-        not_mask = xp.astype(~x.mask, xp.uint64)
-        return xp.sum(not_mask, axis=axis, keepdims=keepdims, dtype=xp.uint64)
+        return xp.count_nonzero(~x.mask, axis=axis, keepdims=keepdims)
 
     def _cumulative_op(x, *args, _identity, _op, **kwargs):
         x = asarray(x)

--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -563,7 +563,7 @@ def masked_namespace(xp):
 
     def count(x, axis=None, keepdims=False):
         x = asarray(x)
-        return xp.count_nonzero(~x.mask, axis=axis, keepdims=keepdims)
+        return asarray(xp.count_nonzero(~x.mask, axis=axis, keepdims=keepdims))
 
     def _cumulative_op(x, *args, _identity, _op, **kwargs):
         x = asarray(x)
@@ -592,7 +592,7 @@ def masked_namespace(xp):
 
     def mean(x, axis=None, keepdims=False):
         s = mod.sum(x, axis=axis, keepdims=keepdims)
-        dtype = xp.uint64 if xp.isdtype(s.dtype, ("bool", "integral")) else s.dtype
+        dtype = xp.int64 if xp.isdtype(s.dtype, ("bool", "integral")) else s.dtype
         n = mod.astype(mod.count(x, axis=axis, keepdims=keepdims), dtype)
         return s / n
 
@@ -601,7 +601,7 @@ def masked_namespace(xp):
         xm = x - m
         xmc = mod.conj(xm) if mod.isdtype(xm.dtype, 'complex floating') else xm
         s = mod.sum(xm*xmc, axis=axis, keepdims=keepdims)
-        dtype = xp.uint64 if xp.isdtype(s.dtype, ("bool", "integral")) else s.dtype
+        dtype = xp.int64 if xp.isdtype(s.dtype, ("bool", "integral")) else s.dtype
         n = mod.astype(mod.count(x, axis=axis, keepdims=keepdims), dtype)
         out = s / (n - correction)
         out = mod.real(out) if mod.isdtype(xm.dtype, 'complex floating') else out

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -1120,6 +1120,21 @@ def test_signature_docs():
     assert mxp.sum.__signature__ == inspect.signature(np.sum)
     assert np.sum.__doc__ in mxp.sum.__doc__
 
+
+@pytest.mark.parametrize('keepdims', [False, True])
+@pytest.mark.parametrize('axis', [-1, 0, (0, 1), None])
+@pytest.mark.parametrize('dtype', dtypes_all)
+@pytest.mark.parametrize('xp', xps)
+def test_count(axis, keepdims, dtype, xp, seed=None):
+    # Not part of the standard... include and test for now
+    mxp = marray.masked_namespace(xp)
+    marrays, masked_arrays, seed = get_arrays(1, dtype=dtype, ndim=(2, 4),
+                                              xp=xp, seed=seed)
+    res = mxp.count(marrays[0], axis=axis, keepdims=keepdims)
+    ref = np.ma.count(masked_arrays[0], axis=axis, keepdims=keepdims)
+    np.testing.assert_equal(np.asarray(res), ref)
+
+
 # To do:
 # - investigate asarray - is copy respected?
 

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -816,6 +816,9 @@ def test_elementwise_binary(f_name, dtype, xp, seed=None):
                           "Only numeric dtypes are allowed",
                           "Only real numeric dtypes are allowed"] + torch_exceptions)
 def test_statistical_array(f_name, keepdims, xp, dtype, seed=None):
+    pass_backend(xp=xp, pass_xp='torch', dtype=dtype, pass_dtypes=['float32', 'complex64'],
+                 fun=f_name, pass_funs=statistical_array, pass_using=pytest.xfail,
+                 reason='Occasional tolerance issues.')
     if dtype.startswith('uint'):
         # should fix this and ensure strict check at the end
         pytest.skip("`np.ma` can't provide reference due to numpy/numpy#27885")

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -347,6 +347,7 @@ torch_exceptions = ["\"abs_cpu\" not implemented for 'Bool",
                     "module 'array_api_compat.torch' has no attribute 'repeat'",
                     "torch.reshape doesn't yet support the copy keyword",
                     "unique_all() not yet implemented for pytorch",
+                    "unsqueeze(): argument 'dim' (position 1) must be int, not tuple",
                     ]
 
 
@@ -844,7 +845,7 @@ def test_statistical_array(f_name, keepdims, xp, dtype, seed=None):
     ref_mask = np.all(masked_arrays[0].mask, axis=axis, **kwargs)
     ref = np.ma.masked_array(ref.data, getattr(ref, 'mask', ref_mask))
     ref = ref.astype(ref_dtype)
-    assert_allclose(res, ref, xp=xp, seed=seed, strict=True, rtol=get_rtol(dtype, xp))
+    assert_allclose(res, ref, xp=xp, seed=seed, strict=True)
 
 @pytest.mark.parametrize("dtype", dtypes_all)
 @pytest.mark.parametrize('xp', xps)
@@ -1327,6 +1328,7 @@ def test_signature_docs():
     assert np.sum.__doc__ in mxp.sum.__doc__
 
 
+@pass_exceptions(allowed=torch_exceptions)
 @pytest.mark.parametrize('keepdims', [False, True])
 @pytest.mark.parametrize('axis', [-1, 0, (0, 1), None])
 @pytest.mark.parametrize('dtype', dtypes_all)
@@ -1338,7 +1340,7 @@ def test_count(axis, keepdims, dtype, xp, seed=None):
                                               xp=xp, seed=seed)
     res = mxp.count(marrays[0], axis=axis, keepdims=keepdims)
     ref = np.ma.count(masked_arrays[0], axis=axis, keepdims=keepdims)
-    np.testing.assert_equal(np.asarray(res), ref)
+    assert_equal(res, np.ma.masked_array(ref), xp=xp, seed=seed)
 
 
 # To do:


### PR DESCRIPTION
~~This should probably wait to merge until after gh-110 (so we can test with PyTorch).~~ Done.

In the meantime, a question is whether array type in = array type out should apply here. The return value of `count` never has masked elements. It is essentially a generalization of `shape[axis]`, which returns a scalar, not an array. 

In SciPy, this is used like:
https://github.com/scipy/scipy/blob/25ca572f6dcaf2d7ad38d96fdc9def33b2f8a385/scipy/stats/_stats_py.py#L1244-L1250

so it works fine returning an `xp` array, not an `mxp` array. I imagine that it could just as well return `mxp` arrays.

Thoughts?
