### PR TITLE
MAINT: unique: indices shouldn't be masked

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -499,7 +499,7 @@ def masked_namespace(xp):
             mask = (res.values == sentinel) if any_masked else None
             result_list = []
             for res_i, field_i in zip(res, fields):
-                mask_i = None if field_i == 'inverse_indices' else mask
+                mask_i = None if field_i in {'inverse_indices', 'indices'} else mask
                 result_list.append(MArray(res_i, mask=mask_i))
             return result_class(*result_list)
 

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -1016,12 +1016,14 @@ def test_set(f_name, dtype, xp, seed=None):
         assert_equal(res.counts, ref_counts, xp=xp, seed=seed)
 
     if hasattr(res, 'indices'):
-        ref_counts = np.ma.masked_array(np.asarray(ref.indices), mask=ref_mask)
-        assert_equal(res.indices, ref_counts, xp=xp, seed=seed)
+        ref_indices = np.ma.masked_array(np.asarray(ref.indices), mask=False)
+        assert_equal(res.indices, ref_indices, xp=xp, seed=seed)
+        assert_equal(mxp.reshape(x, (-1,))[res.indices], res.values, xp=xp, seed=seed)
 
     if hasattr(res, 'inverse_indices'):
-        ref_counts = np.ma.masked_array(np.asarray(ref.inverse_indices), mask=False)
-        assert_equal(res.inverse_indices, ref_counts, xp=xp, seed=seed)
+        ref_inverse = np.ma.masked_array(np.asarray(ref.inverse_indices), mask=False)
+        assert_equal(res.inverse_indices, ref_inverse, xp=xp, seed=seed)
+        assert_equal(res.values[res.inverse_indices], x, xp=xp, seed=seed)
 
 
 @pytest.mark.parametrize("f_name", ['sort', 'argsort'])


### PR DESCRIPTION
In https://github.com/mdhaber/marray/issues/28#issuecomment-2779808353, I did the following test:

```python3
from marray import numpy as mxp

x = mxp.asarray([1, mxp.nan, 5, 1, 3, 3, mxp.nan, mxp.nan, 3],
                 mask=[0, 1, 0, 1, 1, 0, 0, 0, 0])
res = mxp.unique_all(x)
print(x)
print(res.values)
print(res.counts)
print(res.indices)
y = res.values[res.inverse_indices]
print(y)
```

The output looked pretty good:
```
[ 1.   _  5.   _   _  3. nan nan  3.]
[ 1.  3.  5.   _ nan nan]  # masked values are identical, nans are distinct
[1 2 1 _ 1 1]  # there are two 3s, but one of everything else (counting each NaN separately)
[0 5 2 _ 6 7]  # index of first appearance of each element
[ 1.   _  5.   _   _  3. nan nan  3.]  # identical to original
```
But I realized that `res.indices` probably shouldn't have any masked elements; the masked element should probably be `1` to correspond with the first occurrence of a masked element in `x`.

This update ensures that:
> `indices`... must be an array containing the indices (first occurrences) of a flattened `x` that result in `values`

Along these lines, one could also imagine counting the number of masked elements instead of returning a masked value. If we are treating masked values as the same, I suppose we can count them, and it might be nice for the sum of `counts` to equal the size of `x`.