### PR TITLE
MAINT: improve conversion of masked values to Python scalars

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -202,7 +202,13 @@ def masked_namespace(xp):
     unary_names_py = ['__bool__', '__complex__', '__float__', '__index__', '__int__']
     for name in unary_names_py:
         def fun(self, name=name):
-            return self._call_super_method(name)
+            res = self._call_super_method(name)
+            if res and not self.mask:
+                return res
+            if name in {'__complex__', '__float__'}:
+                return res * mod.nan
+            raise ValueError(f"Cannot convert masked value to `{name.strip('_')}`.")
+
         setattr(MArray, name, fun)
 
     # Methods that return the result of an elementwise binary operation

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -319,7 +319,7 @@ def test_indexing(xp):
     assert isinstance(x[1], type(x))
 
     # Test `__setitem__`/`__getitem__` roundtrip with masked array as index
-    i = mxp.asarray(1, mask=True)
+    i = mxp.asarray(1, mask=False)
     x[i.__index__()] = 20
     assert x[i.__index__()] == 20
     assert isinstance(x[i.__index__()], type(x))


### PR DESCRIPTION
Willl close gh-28

Turns out there are some tests that currently depend on `__bool__` and `__index__` to be defined. For instance, that `xp.all([])` is True makes sense in some applications and this sort of logic is relied on in some tests. But `mxp.all(mxp.asarray([]))` currently returns a _masked_ True. With the current behavior, this evaluates to `True` when forced to be boolean, consistent with `xp.all([])`, but now it raises.

I'll have to a take a closer look at the tests to see if we *really* rely on this behavior or if they just need to be refactored.