### PR TITLE
MAINT: allow use of 'device' in asarray

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -47,13 +47,14 @@ def masked_namespace(xp):
 
         def __init__(self, data, mask=None):
             data = xp.asarray(_get_data(data))
-            mask = (xp.zeros(data.shape, dtype=xp.bool) if mask is None
-                    else xp.asarray(mask, dtype=xp.bool))
+            device = getattr(data, "device", None)  # accommodate Dask
+            mask = (xp.zeros(data.shape, dtype=xp.bool, device=device) if mask is None
+                    else xp.asarray(mask, dtype=xp.bool, device=device))
             if mask.shape != data.shape:  # avoid copy if possible
                 mask = xp.asarray(xp.broadcast_to(mask, data.shape), copy=True)
             self._data = data
             self._dtype = data.dtype
-            self._device = getattr(data, "device", None)  # accommodate Dask
+            self._device = device
             # assert data.device == mask.device
             self._ndim = data.ndim
             self._shape = data.shape
@@ -252,13 +253,11 @@ def masked_namespace(xp):
 
     ## Creation Functions ##
     def asarray(obj, /, *, mask=None, dtype=None, device=None, copy=None):
-        if device is not None:
-            raise NotImplementedError("`device` argument is not implemented")
-
         data = _get_data(obj)
         data = xp.asarray(data, dtype=dtype, device=device, copy=copy)
+        device = getattr(data, 'device', None)
 
-        mask = (getattr(obj, 'mask', xp.full(data.shape, False))
+        mask = (getattr(obj, 'mask', xp.zeros(data.shape, dtype=xp.bool, device=device))
                 if mask is None else mask)
         mask = xp.asarray(mask, dtype=xp.bool, device=device, copy=copy)
 

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -1145,12 +1145,11 @@ def test_astype(dtype_in, dtype_out, copy, xp, seed=None):
     assert_equal(res, ref, xp=xp, seed=seed)
 
 
-@pytest.mark.parametrize('xp', xps)
-def test_asarray_device(xp):
+def test_asarray_device(xp=np):
     mxp = marray.masked_namespace(xp)
-    message = "`device` argument is not implemented"
-    with pytest.raises(NotImplementedError, match=message):
-        mxp.asarray(xp.asarray([1, 2, 3]), device='coconut')
+    device = 'cpu'
+    x = mxp.asarray(xp.asarray([1, 2, 3]), device=device)
+    assert x.device == x.data.device == x.mask.device == device
 
 
 @pytest.mark.parametrize('dtype', dtypes_all)
@@ -1347,4 +1346,4 @@ def test_gh99(xp):
 def test_test():
     # dev tool to reproduce a particular failure of a `parametrize`d test
     seed = 91803015965563856304156452253329804912
-    test_nonzero("complex128", torch, seed=seed)
+    test_nonzero("complex128", np, seed=seed)


### PR DESCRIPTION
Toward gh-25.

Not extensively tested. This doesn't close _ gh-25; we can improve later.