### PR TITLE
Revert __setitem__ changes of gh-108 and increment version number

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -2,7 +2,7 @@
 Masked versions of array API compatible arrays
 """
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 
 import collections
 import dataclasses
@@ -134,19 +134,7 @@ def masked_namespace(xp):
             key = self._validate_key(key)
             return MArray(self.data[key], self.mask[key])
 
-        def _set_item_bool(self, key, other):
-            # Sets elements for each element of `key` that is True OR masked
-            # Elements are masked wherever either `other` or `key` were masked
-            key_data, key_mask = _get_data_mask(key)
-            other_data, other_mask = _get_data_mask(other)
-            i = key_data | key_mask
-            mask = xp.broadcast_to(xp.asarray(other_mask | key_mask), self.shape)
-            self.mask[i] = mask[i]
-            return self.data.__setitem__(i, other_data)
-
         def __setitem__(self, key, other):
-            if _is_boolean(key, xp) and _get_size(key) > 0:
-                return self._set_item_bool(key, other)
             key = self._validate_key(key)
             self.mask[key] = getattr(other, 'mask', False)
             return self.data.__setitem__(key, _get_data(other))

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -536,32 +536,33 @@ def test_boolean_indexing(xp, seed=None):
         i_empty = mxp.asarray([], dtype=mxp.bool)  # special case
         assert_equal(x[i_empty], x[1:1], xp=xp, seed=seed)
 
-    # __setitem__
-    x2 = mxp.asarray(x, copy=True)
-    x2[i] = 9
-    data = xp.asarray(x.data, copy=True)
-    mask = xp.asarray(x.mask, copy=True)
-    data[i.data & ~i.mask] = 9
-    mask[i.data & ~i.mask] = False
-    mask[i.mask] = True
-    ref = mxp.asarray(data, mask=mask)
-    assert_equal(x2, ref, xp=xp, seed=seed)
-
-    x2 = mxp.asarray(x, copy=True)
-    x2[i] = mxp.asarray(9, mask=True)
-    data = xp.asarray(x.data, copy=True)
-    mask = xp.asarray(x.mask, copy=True)
-    # Data assignment doesn't matter, since `other` is masked
-    mask[i.data] = True
-    mask[i.mask] = True
-    ref = mxp.asarray(data, mask=mask)
-    assert_equal(x2, ref, xp=xp, seed=seed)
-
-    if "torch" not in xp.__name__:  # torch doesn't implement this
-        x2 = mxp.asarray(x, copy=True)
-        x2[i_empty] = 9
-        x2[i_empty] = mxp.asarray(9, mask=True)
-        assert_equal(x2, x, xp=xp, seed=seed)
+    # Reverted this part of gh-108 to address gh-123
+    # # __setitem__
+    # x2 = mxp.asarray(x, copy=True)
+    # x2[i] = 9
+    # data = xp.asarray(x.data, copy=True)
+    # mask = xp.asarray(x.mask, copy=True)
+    # data[i.data & ~i.mask] = 9
+    # mask[i.data & ~i.mask] = False
+    # mask[i.mask] = True
+    # ref = mxp.asarray(data, mask=mask)
+    # assert_equal(x2, ref, xp=xp, seed=seed)
+    #
+    # x2 = mxp.asarray(x, copy=True)
+    # x2[i] = mxp.asarray(9, mask=True)
+    # data = xp.asarray(x.data, copy=True)
+    # mask = xp.asarray(x.mask, copy=True)
+    # # Data assignment doesn't matter, since `other` is masked
+    # mask[i.data] = True
+    # mask[i.mask] = True
+    # ref = mxp.asarray(data, mask=mask)
+    # assert_equal(x2, ref, xp=xp, seed=seed)
+    #
+    # if "torch" not in xp.__name__:  # torch doesn't implement this
+    #     x2 = mxp.asarray(x, copy=True)
+    #     x2[i_empty] = 9
+    #     x2[i_empty] = mxp.asarray(9, mask=True)
+    #     assert_equal(x2, x, xp=xp, seed=seed)
 
 
 @pytest.mark.parametrize("dtype", dtypes_all)


### PR DESCRIPTION
This closes gh-123 and re-opens the `__setitem__` part of gh-108; the logic just wasn't correct for array right hand sides.