### PR TITLE
ENH: automatically import some modules from `array_api_compat`

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -20,8 +20,19 @@ __all__ = ["masked_namespace"]
 
 
 def __getattr__(name):
+
+    base = ""
+    if name in {'torch', 'cupy'}:
+        try:
+            import array_api_compat
+            base = 'array_api_compat.'
+        except ModuleNotFoundError as e:
+            message = ("`array_api_compat` is required when using `marray` with ",
+                       f"backend `{name}`. Please install `array_api_compat`.")
+            raise ModuleNotFoundError(message)
+
     try:
-        xp = importlib.import_module(name)
+        xp = importlib.import_module(base+name)
         mod = masked_namespace(xp)
         sys.modules[f"marray.{name}"] = mod
         return mod

--- a/mybook/tutorial.md
+++ b/mybook/tutorial.md
@@ -17,7 +17,7 @@ kernelspec:
 
 MArray is a package for extending your favorite [Python Array API Standard](https://data-apis.org/array-api/latest/index.html) compatible library with mask capabilities. Motivation for masked arrays can be found at ["What is a masked array?"](https://numpy.org/devdocs/reference/maskedarray.generic.html#what-is-a-masked-array).
 
-MArray is easy to install with `pip`, and it has no required dependencies.
+MArray is easy to install with `pip`, and it has no required dependencies. (However, `array_api_compat` is needed when using backends that are not yet array API compatible, such as PyTorch and CuPy.)
 
 ```{code-cell} ipython3
 # !pip install marray


### PR DESCRIPTION
Now, when doing e.g.:
```python3
from marray import torch as mxp
```
actually import `torch` from `array_api_compat`, since it really doesn't work otherwise.

The latest version of CuPy might not need this treatment, but I've added it anyway. I'll test it shortly.

If this optional dependency should be noted in `pyproject.toml` or such, please commit here or open a separate PR.