### PR TITLE
MAINT: updates to fix errors in array-api-strict 2.4

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -487,7 +487,7 @@ def masked_namespace(xp):
     def nonzero(x, /):
         x = asarray(x)
         data = xp.asarray(x.data, copy=True)
-        data[x.mask] = 0
+        data[x.mask] = xp.asarray(0, dtype=data.dtype)
         res = xp.nonzero(data)
         return tuple(MArray(resi) for resi in res)
 
@@ -590,7 +590,7 @@ def masked_namespace(xp):
                             'any': False}
             x = asarray(x)
             data = xp.asarray(x.data, copy=True)
-            data[x.mask] = replacements[name]
+            data[x.mask] = xp.asarray(replacements[name], dtype=data.dtype)
             fun = getattr(xp, name)
             res = fun(data, *args, axis=axis, **kwargs)
             mask = xp.all(x.mask, axis=axis, keepdims=kwargs.get('keepdims', False))
@@ -609,7 +609,7 @@ def masked_namespace(xp):
 
         data = xp.asarray(x.data, copy=True)
         mask = x.mask
-        data[mask] = _identity
+        data[mask] = xp.asarray(_identity, dtype=data.dtype)
         res = _op(data, *args, **kwargs)
 
         if kwargs.get('include_initial', False):

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -682,6 +682,9 @@ def test_inplace_array_binary(f, dtype, xp, seed=None):
                           "ZeroDivisionError"
                           ] + torch_exceptions)
 def test_rarithmetic_binary(f_name, f, dtype, xp, type_, seed=None):
+    pass_backend(xp=xp, pass_xp='strict', dtype=dtype, pass_dtypes=dtypes_all,
+                 pass_using=pytest.skip,
+                 reason='Strict arrays do not support reflected operations')
     pass_backend(xp=xp, pass_xp='torch', dtype=dtype, pass_dtypes=['complex64'],
                  fun=f_name, pass_funs=["x ** y", "x.__pow__(y)"], pass_using=pytest.xfail,
                  reason='Occasional tolerance issues.')
@@ -705,6 +708,9 @@ def test_rarithmetic_binary(f_name, f, dtype, xp, type_, seed=None):
                          + torch_exceptions)
 def test_rarray_binary(dtype, xp, seed=None):
     # very restrictive operator -> limited test
+    pass_backend(xp=xp, pass_xp='strict', dtype=dtype, pass_dtypes=dtypes_all,
+                 pass_using=pytest.skip,
+                 reason='Strict arrays do not support reflected operations')
     mxp = marray.masked_namespace(xp)
     rng = np.random.default_rng(seed)
     data = (rng.random((3, 10, 10))*10).astype(dtype)
@@ -723,6 +729,9 @@ def test_rarray_binary(dtype, xp, seed=None):
 @pytest.mark.parametrize('xp', xps)
 @pass_exceptions(allowed=["Only integer dtypes are allowed in"] + torch_exceptions)
 def test_rbitwise_binary(f, dtype, xp, seed=None):
+    pass_backend(xp=xp, pass_xp='strict', dtype=dtype, pass_dtypes=dtypes_all,
+                 pass_using=pytest.skip,
+                 reason='Strict arrays do not support reflected operations')
     marrays, masked_arrays, seed = get_arrays(2, dtype=dtype, xp=xp, seed=seed)
     res = f(marrays[0].data, marrays[1])
     ref = f(masked_arrays[0].data, masked_arrays[1])
@@ -769,8 +778,11 @@ def test_dtype_inspection_version(f, xp):
 def test_finfo(dtype, xp, seed=None):
     mxp = marray.masked_namespace(xp)
     marrays, _, _ = get_arrays(1, dtype=dtype, xp=xp, seed=seed)
-    dype_mxp, dtype_xp = getattr(mxp, dtype), getattr(xp, dtype)
-    assert mxp.finfo(dype_mxp) == xp.finfo(dtype_xp)
+    dtype_mxp, dtype_xp = getattr(mxp, dtype), getattr(xp, dtype)
+    for attribute in ['bits', 'eps', 'max', 'min', 'smallest_normal', 'dtype']:
+        res = getattr(mxp.finfo(dtype_mxp), attribute)
+        ref = getattr(xp.finfo(dtype_xp), attribute)
+        assert res == ref
     # see numpy/numpy#22977, data_apis/array_api_strict#116
     # assert mxp.finfo(marrays[0]) == xp.finfo(dtype)
 
@@ -1028,6 +1040,8 @@ def test_tri(f_name, dtype, xp, seed=None):
 @pytest.mark.parametrize('xp', xps)
 @pass_exceptions(allowed=torch_exceptions)
 def test_meshgrid(indexing, dtype, xp, seed=None):
+    pass_backend(xp=xp, pass_xp='torch', pass_using=pytest.xfail,
+                 reason='PyTorch ij indexing no longer working.')
     mxp = marray.masked_namespace(xp)
     rng = np.random.default_rng(seed)
     n = rng.integers(1, 4)
@@ -1121,7 +1135,7 @@ def test_nonzero(dtype, xp, seed=None):
     x, y = marrays[0], masked_arrays[0]
     rng = np.random.default_rng(seed)
     cond = rng.random(marrays[0].shape) > 0.5
-    x[xp.asarray(cond)] = 0
+    x[xp.asarray(cond)] = xp.asarray(0, dtype=x.dtype)
     y[cond] = 0
     res = mxp.nonzero(x)
     ref = np.ma.nonzero(y)

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -1041,7 +1041,7 @@ def test_tri(f_name, dtype, xp, seed=None):
 @pass_exceptions(allowed=torch_exceptions)
 def test_meshgrid(indexing, dtype, xp, seed=None):
     pass_backend(xp=xp, pass_xp='torch', pass_using=pytest.xfail,
-                 reason='PyTorch ij indexing no longer working.')
+                 reason='data-apis/array-api-compat#340')
     mxp = marray.masked_namespace(xp)
     rng = np.random.default_rng(seed)
     n = rng.integers(1, 4)


### PR DESCRIPTION
Updates to address failures with array-api-strict 2.4. ~~Should allow~~ Allows un-skipping array-api-strict added by scipy/scipy#23381 (confirmed locally).

Note: https://github.com/data-apis/array-api-strict/pull/145#issuecomment-3148732475
~~Also should investigate why torch meshgrid test is failing now if it wasn't before.~~ data-apis/array-api-compat#340