### PR TITLE
MAINT: fix `array-api-strict` test failures

### DIFF
--- a/marray/__init__.py
+++ b/marray/__init__.py
@@ -609,7 +609,7 @@ def masked_namespace(xp):
         x = asarray(x)
         axis = kwargs.get('axis', None)
         if axis is None:
-            x = mod.reshape(x, -1)
+            x = mod.reshape(x, (-1,))
 
         data = xp.asarray(x.data, copy=True)
         mask = x.mask

--- a/marray/tests/test_marray.py
+++ b/marray/tests/test_marray.py
@@ -594,6 +594,25 @@ def test_take_along_axis(dtype, xp, seed=None):
 
 
 @pytest.mark.parametrize("dtype", dtypes_all)
+@pytest.mark.parametrize("xp", xps)
+@pass_exceptions(allowed=torch_exceptions)
+def test_take(dtype, xp, seed=None):
+    mxp = marray.masked_namespace(xp)
+    marrays, masked_arrays, seed = get_arrays(1, dtype=dtype, xp=xp, seed=seed)
+    ndim = marrays[0].ndim
+    shape = marrays[0].shape
+
+    rng = np.random.default_rng(seed)
+    axis = rng.integers(-ndim, ndim)
+    index_size = rng.integers(100)
+    indices = rng.integers(shape[axis], size=index_size)
+
+    res = mxp.take(marrays[0], xp.asarray(indices), axis=axis)
+    ref = np.ma.take(masked_arrays[0], indices, axis=axis)
+    assert_equal(res, ref, xp=xp, seed=seed)
+
+
+@pytest.mark.parametrize("dtype", dtypes_all)
 @pytest.mark.parametrize('xp', xps)
 @pass_exceptions(allowed=["object has no attribute 'to_device'"])  # torch/cupy
 def test_dlpack(dtype, xp, seed=None):
@@ -1451,5 +1470,5 @@ def test_gh99(xp):
 
 def test_test():
     # dev tool to reproduce a particular failure of a `parametrize`d test
-    seed = 91803015965563856304156452253329804912
-    test_nonzero("complex128", np, seed=seed)
+    seed = 98806759374046640850898260001383604577
+    test_take("bool", np, seed=seed)


### PR DESCRIPTION
Fixes the test failures observed in gh-136.

~~Looks like we need our own test of `take`. If [`np.ma.take`](https://numpy.org/doc/stable/reference/generated/numpy.ma.masked_array.take.html) implementation agrees reasonably well with the array API standard, it shouldn't be too hard.~~ *Done*.